### PR TITLE
Improve performance of keyword completion

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -119,15 +119,21 @@ variable for additional information about STRING and STATUS."
         (docker-compose--find-subtree (cdr nodes) (cdr subtree)))
     tree))
 
+(defun docker-compose--filter-candidates-tree (prefix tree)
+  "Return a list of candidate keywords matching a PREFIX in a keyword TREE."
+  (let ((candidates nil))
+    (dolist (subtree tree (nreverse candidates))
+      (when (string-prefix-p prefix (car subtree))
+        (push (car subtree) candidates)))))
+
 (defun docker-compose--candidates (prefix)
   "Obtain applicable candidates from the keywords list for the PREFIX."
   (-let* ((keywords (docker-compose--keywords-for-buffer))
           (nodes (docker-compose--find-context))
-          (subtree (docker-compose--find-subtree nodes keywords))
-          (viable-candidates (-map #'car subtree) ))
+          (subtree (docker-compose--find-subtree nodes keywords)))
     (if prefix
-        (--filter (string-prefix-p prefix it) viable-candidates)
-      viable-candidates)))
+        (docker-compose--filter-candidates-tree prefix subtree)
+      (-map #'car subtree))))
 
 (defun docker-compose--prefix ()
   "Get a prefix and its starting and ending points from the current position."

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -88,32 +88,25 @@ variable for additional information about STRING and STATUS."
   (when (eq status 'finished)
     (insert ": ")))
 
-(defun docker-compose--indentation-of-current-line ()
-  "Return the indentation of the current line."
-  (save-excursion
-    (beginning-of-line)
-    (when (looking-at "^[\t ]+")
-      (length (match-string-no-properties 0)))))
-
-(defun docker-compose--indentation-and-keyword-of-current-line ()
+(defsubst docker-compose--indentation-and-keyword-of-current-line ()
   "Return the indentation and keyword, if present, of the current line."
-  (save-excursion
-    (beginning-of-line)
-    (when (looking-at "^\\([\t ]*\\)\\([a-zA-Z][a-zA-Z0-9_]+\\)?:")
-      (list (length (match-string-no-properties 1))
-            (match-string-no-properties 2)))))
+  (beginning-of-line)
+  (let ((indentation (skip-chars-forward "\t ")))
+    (when (looking-at "\\([a-zA-Z][a-zA-Z0-9_]+\\)?:")
+      (list indentation (match-string-no-properties 1)))))
 
 (defun docker-compose--find-context ()
   "Return a list with the ancestor keys of the current point."
   (save-excursion
+    (beginning-of-line)
     (-let* ((keywords '())
-            (previous-indentation (or (docker-compose--indentation-of-current-line) 0)))
+            (previous-indentation (skip-chars-forward "\t ")))
       (cl-loop
        do
        (forward-line -1)
        (-let (((current-indentation keyword) (docker-compose--indentation-and-keyword-of-current-line)))
          (when (and current-indentation (< current-indentation previous-indentation))
-           (setq keywords (cons keyword keywords )
+           (setq keywords (cons keyword keywords)
                  previous-indentation current-indentation)))
        until (or (= previous-indentation 0) (bobp)))
       keywords)))


### PR DESCRIPTION
## Benchmark

#### `emacs-version`

```
GNU Emacs 26.0.50 (build 2, x86_64-apple-darwin15.6.0, NS appkit-1404.47 Version 10.11.6 (Build 15G1611)) of 2017-08-09
```

#### Command
Average of 10 runs of 100,000 executions of `docker-compose--keyword-complete-at-point`:

```
emacs -batch -l $PATH_TO_DASH_ELC --eval '(byte-compile-file "docker-compose-mode.el")'  --eval '(progn (require \'docker-compose-mode "docker-compose-mode.elc") (with-temp-buffer (insert "version: 2\\nservices:\\n  web:\\n    image: foo\\n    env") (goto-char 51) (print (--map (/ it 10.0) (-reduce (-lambda ((x y z) (a b c)) (list (+ x a) (+ y b) (+ z c))) (cl-loop for _ from 1 to 10 collect (benchmark-run 100000 (docker-compose--keyword-complete-at-point))))))))'
```

## Results

The format of the results is `(total-time calls-to-gc time-spent-in-gc)`.

| Version | Default gc-cons-threshold (800000) | Tweaked gc-cons-threshold (50000000) |
| --- | --- | --- |
| 0.3.1 | (3.9410499999999997 202.4 2.0517979999999985) | (2.0875664 3.9 0.1580317) |
| Proposed| (2.2782732 79.7 0.8026095999999999) | (1.5886463000000002 1.5 0.0677287) |