### PR TITLE
Avoid allocation of unnecessary list

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -88,26 +88,22 @@ variable for additional information about STRING and STATUS."
   (when (eq status 'finished)
     (insert ": ")))
 
-(defsubst docker-compose--indentation-and-keyword-of-current-line ()
-  "Return the indentation and keyword, if present, of the current line."
-  (beginning-of-line)
-  (let ((indentation (skip-chars-forward "\t ")))
-    (when (looking-at "\\([a-zA-Z][a-zA-Z0-9_]+\\)?:")
-      (list indentation (match-string-no-properties 1)))))
-
 (defun docker-compose--find-context ()
   "Return a list with the ancestor keys of the current point."
   (save-excursion
     (beginning-of-line)
-    (-let* ((keywords '())
-            (previous-indentation (skip-chars-forward "\t ")))
+    (-let* ((keywords nil)
+            (previous-indentation (skip-chars-forward "\t "))
+            (current-indentation nil))
       (cl-loop
        do
        (forward-line -1)
-       (-let (((current-indentation keyword) (docker-compose--indentation-and-keyword-of-current-line)))
-         (when (and current-indentation (< current-indentation previous-indentation))
-           (setq keywords (cons keyword keywords)
-                 previous-indentation current-indentation)))
+       (setq current-indentation (skip-chars-forward "\t "))
+       (when (and (< current-indentation previous-indentation)
+                  (looking-at "\\([a-zA-Z][a-zA-Z0-9_]+\\):"))
+         (setq previous-indentation current-indentation)
+         (push (match-string-no-properties 1) keywords))
+
        until (or (= previous-indentation 0) (bobp)))
       keywords)))
 


### PR DESCRIPTION
## Benchmark

#### `emacs-version`

```
GNU Emacs 26.0.50 (build 2, x86_64-apple-darwin15.6.0, NS appkit-1404.47 Version 10.11.6 (Build 15G1611)) of 2017-08-09
```

#### Command
Average of 10 runs of 100,000 executions of `docker-compose--keyword-complete-at-point`:

```
emacs -batch -l $PATH_TO_DASH_ELC --eval '(byte-compile-file "docker-compose-mode.el")'  --eval '(progn (require \'docker-compose-mode "docker-compose-mode.elc") (with-temp-buffer (insert "version: 2\\nservices:\\n  web:\\n    image: foo\\n    env") (goto-char 51) (print (--map (/ it 10.0) (-reduce (-lambda ((x y z) (a b c)) (list (+ x a) (+ y b) (+ z c))) (cl-loop for _ from 1 to 10 collect (benchmark-run 100000 (docker-compose--keyword-complete-at-point))))))))'
```

## Results

The format of the results is `(total-time calls-to-gc time-spent-in-gc)`.

| Version | Default gc-cons-threshold (800000) | Tweaked gc-cons-threshold (50000000) |
| --- | --- | --- |
| 0.3.2 | (2.3146096 79.7 0.8174644999999995) | (1.5619215 1.5 0.06770069999999999) |
| Proposed| (2.0576919 64.7 0.6595541999999999) | (1.4689036 1.2 0.05582499999999999) |