### PR TITLE
Improve version parsing and handling

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -78,9 +78,9 @@ version 1."
 
 (defun docker-compose--keywords-for-buffer ()
   "Obtain keywords appropriate for the current buffer's docker-compose version."
-  (let ((version
-         (docker-compose--normalize-version (docker-compose--find-version))))
-    (cdr (assoc version docker-compose-keywords))))
+  (-when-let* ((version (-some-> (docker-compose--find-version)
+                                 (docker-compose--normalize-version))))
+      (cdr (assoc version docker-compose-keywords))))
 
 (defun docker-compose--post-completion (_string status)
   "Execute actions after completing with candidate.

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -66,8 +66,9 @@ It is assumed that files lacking an explicit 'version' key are
 version 1."
   (save-excursion
     (goto-char (point-min))
-    (if (looking-at "^version:\s*[\\'\"]?\\([2-9]\\(?:\.[0-9]\\)?\\)[\\'\"]?$")
-        (match-string-no-properties 1)
+    (if (re-search-forward "^version:\s*" (point-at-eol) t 1)
+        (when (looking-at "\\([\"']\\)\\([0-9]\\(?:\.[0-9]+\\(?:-\\w+\\)?\\)?\\)\\1$")
+          (match-string-no-properties 2))
       "1.0")))
 
 (defun docker-compose--normalize-version (version)

--- a/tests/test-docker-compose-mode.el
+++ b/tests/test-docker-compose-mode.el
@@ -49,6 +49,13 @@
       (let ((expected-candidates '("env_file" "environment")))
         (expect (docker-compose--candidates "env") :to-equal expected-candidates)))
 
+    (describe "when the buffer version is invalid"
+      (it "returns nil"
+        (with-temp-buffer
+          (insert "version: 2\nservices:\n  consumer:\n    build: .\n\n  web:\n    image: foo\n\nnet")
+          (goto-char 74)
+          (expect (docker-compose--candidates "net") :to-equal nil))))
+
     (describe "when no applicable candidates are available"
       (it "returns nil"
         (spy-on 'docker-compose--keywords-for-buffer '())


### PR DESCRIPTION
- Return no candidates when the version is invalid
- Improve version regular expression:
  - The version must always be surrounded by either single or double quotes
  - The version may include a suffix separated with a dash