### PR TITLE
Fix namespace of keyword completion function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Fix namespace of keyword completion function (`docker-compose--keyword-complete-at-point` → `docker-compose-keyword-complete-at-point`)
+
 ## [0.3.5] - 2017-09-10
 
 ### Changed

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -140,7 +140,7 @@ variable for additional information about STRING and STATUS."
     (when (looking-at "^[\t ]*\\([a-zA-Z][a-zA-Z0-9_]+\\)$")
       (list (match-string-no-properties 1) (match-beginning 1) (match-end 1)))))
 
-(defun docker-compose--keyword-complete-at-point ()
+(defun docker-compose-keyword-complete-at-point ()
   "`completion-at-point-functions' function for docker-compose keywords."
   (-when-let* (((prefix start end) (docker-compose--prefix)))
     (list start end (docker-compose--candidates prefix)
@@ -152,7 +152,7 @@ variable for additional information about STRING and STATUS."
 (define-derived-mode docker-compose-mode yaml-mode "docker-compose"
   "Major mode to edit docker-compose files."
   (setq-local completion-at-point-functions
-              '(docker-compose--keyword-complete-at-point)))
+              '(docker-compose-keyword-complete-at-point)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist


### PR DESCRIPTION
The keyword completion function, `docker-compose-keyword-complete-at-point`, is a public function and should be named accordingly.