### PR TITLE
Revert "Use non-stable packages for testing"

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,5 +1,5 @@
 (source gnu)
-(source melpa)
+(source melpa-stable)
 
 (depends-on "dash")
 (depends-on "yaml-mode")


### PR DESCRIPTION
This reverts commit 87ef2dc1a4e64f3f2a507dceddaf1ff2af285ee9.

Buttercup 1.9 was released, which fixes the issue described by the reverted commit.