### PR TITLE
When a version is unknown but valid, assume a recent version

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -78,10 +78,14 @@ version 1."
     version))
 
 (defun docker-compose--keywords-for-buffer ()
-  "Obtain keywords appropriate for the current buffer's docker-compose version."
+  "Obtain keywords appropriate for the current buffer's docker-compose version.
+
+If the version is not present in `docker-compose-keywords', the
+final (most recent) entry in it is used."
   (-when-let* ((version (-some-> (docker-compose--find-version)
                                  (docker-compose--normalize-version))))
-      (cdr (assoc version docker-compose-keywords))))
+      (cdr (or (assoc version docker-compose-keywords)
+               (car (last docker-compose-keywords))))))
 
 (defun docker-compose--post-completion (_string status)
   "Execute actions after completing with candidate.

--- a/tests/test-docker-compose-mode.el
+++ b/tests/test-docker-compose-mode.el
@@ -56,6 +56,14 @@
           (goto-char 74)
           (expect (docker-compose--candidates "net") :to-equal nil))))
 
+    (describe "when the buffer version looks valid but is unknown"
+      (it "completes as if it was a recent version"
+        (with-temp-buffer
+          (insert "version: '9.99'\nservices:\n  consumer:\n    build: .\n\n  web:\n    image: foo\n\nnet")
+          (goto-char 76)
+          (expect (docker-compose--prefix) :to-equal '("net" 76 79))
+          (expect (docker-compose--candidates "net") :to-equal '("networks")))))
+
     (describe "when no applicable candidates are available"
       (it "returns nil"
         (spy-on 'docker-compose--keywords-for-buffer '())


### PR DESCRIPTION
This allows the completion to be useful even when it has not yet been
updated for the most recent versions of the file format.