### PR TITLE
Add interactive execution of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Alternatively, if you prefer using `use-package`:
 (use-package docker-compose-mode)
 ```
 
+Functions to perform docker-compose commands are provided they are:
+```
+docker-compose-run-buffer
+docker-compose-build-buffer
+docker-compose-restart-buffer
+docker-compose-stop-buffer
+docker-compose-down-buffer
+docker-compose-pause-buffer
+docker-compose-unpause-buffer
+docker-compose-start-buffer
+```
+They can be bound to the docker key map as follows:
+```
+(define-key docker-compose-mode-map (kbd "C-c C-r") #'docker-compose-run-buffer)
+```
+
+
 ## Customization
 
 By default, the keyword completion function detects the docker-compose version

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -62,6 +62,16 @@
   :type '(alist :key-type string :value-type (repeat string))
   :group 'docker-compose)
 
+(defvar docker-compose-all-services-token "*all services*"
+  "Special token used to mark usage of all services when selecting
+  interactively")
+
+(defvar docker-compose-commands
+  '(build bundle config create down events exec help images kill
+    logs pause port ps pull push restart rm run scale start stop
+    top unpause up version)
+  "Commands that can be executed")
+
 (defun docker-compose--find-version ()
   "Find the version of the docker-compose file.
 It is assumed that files lacking an explicit 'version' key are
@@ -154,14 +164,57 @@ variable for additional information about STRING and STATUS."
           :company-docsig #'identity
           :exit-function #'docker-compose--post-completion)))
 
-(defun docker-compose--execute-command (command)
+(defun docker-compose-select-command ()
+  "Interactively select a command to run"
+  (completing-read "command: " docker-compose-commands))
+
+(defun docker-compose--get-services ()
+  "Interactively select a command to run"
+  (let ((services (split-string
+                   (shell-command-to-string
+                    (format "docker-compose -f \"%s\" config --services"
+                            (buffer-file-name))))))
+    (add-to-list 'services docker-compose-all-services-token)))
+
+(defun docker-compose-select-service ()
+  "Interactively select a service"
+  (completing-read "command: " (docker-compose--get-services)))
+
+(defun docker-compose-execute-command (command &optional service)
+  "Run a single docker-compose command on one or all services
+
+If no command or service are given, prompt for them interactively."
+  (interactive
+   (list (docker-compose-select-command)
+         (docker-compose-select-service)))
+
+  (docker-compose--execute-command command service))
+
+(defun docker-compose--execute-command (command &optional service)
   "Helper that runs a single docker-compose command"
   (save-buffer)
 
-  (compile
-   (format "docker-compose -f \"%s\" %s" (buffer-file-name) command))
+  ;; If there isn't already a service set, prompt for it
+  (setq service (or service (docker-compose-select-service)))
 
-  (let ((bn (format "*docker-compose:%s*" command)))
+  ;; Define the compilation command to run and execute it
+  (let ((target (format "docker-compose -f \"%s\" %s"
+                        (buffer-file-name)
+                        command)))
+    ;; If a service is set, we need to add it to the command
+    (when (not (string-equal service docker-compose-all-services-token))
+      (setq target (format "%s %s" target service)))
+
+    (compile target))
+
+  ;; Rename the compilation buffer so that the buffer contains the
+  ;; command and the name of the service. If projectile is available,
+  ;; the current project name is used as a prefix. If not,
+  ;; "docker-compose" is used.
+  (let* ((prefix (if (featurep 'projectile)
+                     (projectile-project-name)
+                   "docker-compose"))
+         (bn (format "*%s:%s:%s*" prefix command service)))
     ;; Kill the target buffer if it already exists...
     (when (get-buffer bn)
       (kill-buffer bn))

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -154,78 +154,55 @@ variable for additional information about STRING and STATUS."
           :company-docsig #'identity
           :exit-function #'docker-compose--post-completion)))
 
+(defun docker-compose--execute-command (command)
+  "Helper that runs a single docker-compose command"
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" %s"
+            (convert-standard-filename (buffer-file-name))
+            command)
+       "*docker-compose-output*"))
+
 (defun docker-compose-run-buffer ()
   "Runs the containers that are in the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" up -d"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "up -d"))
 
 (defun docker-compose-build-buffer ()
   "Builds container images for the containers listed in the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" build"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "build"))
 
 (defun docker-compose-restart-buffer ()
   "Restarts the containers listed in the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" restart"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "restart"))
 
 (defun docker-compose-stop-buffer ()
   "Stops the containers in the current buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" stop"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "stop"))
 
 (defun docker-compose-down-buffer ()
   "Runs docker-compose down on the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" down"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "down"))
 
 (defun docker-compose-pause-buffer ()
   "Pauses the containers within the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" pause"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "pause"))
 
 (defun docker-compose-unpause-buffer ()
   "Unpause the containers within the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" unpause"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "unpause"))
 
 
 (defun docker-compose-start-buffer ()
   "Starts the containers listed in the buffer"
   (interactive)
-  (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" start"
-               (standard-filename (buffer-file-name)))
-       "*dockercompose-output*"))
+  (docker-compose--execute-command "start"))
 
 
 ;;;###autoload

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -157,11 +157,17 @@ variable for additional information about STRING and STATUS."
 (defun docker-compose--execute-command (command)
   "Helper that runs a single docker-compose command"
   (save-buffer)
-  (async-shell-command
-    (format "docker-compose -f \"%s\" %s"
-            (convert-standard-filename (buffer-file-name))
-            command)
-       "*docker-compose-output*"))
+
+  (compile
+   (format "docker-compose -f \"%s\" %s" (buffer-file-name) command))
+
+  (let ((bn (format "*docker-compose:%s*" command)))
+    ;; Kill the target buffer if it already exists...
+    (when (get-buffer bn)
+      (kill-buffer bn))
+    ;; ...and then rename the compliation buffer to that one
+    (with-current-buffer (get-buffer "*compilation*")
+      (rename-buffer bn))))
 
 (defun docker-compose-run-buffer ()
   "Runs the containers that are in the buffer"

--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -154,6 +154,80 @@ variable for additional information about STRING and STATUS."
           :company-docsig #'identity
           :exit-function #'docker-compose--post-completion)))
 
+(defun docker-compose-run-buffer ()
+  "Runs the containers that are in the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" up -d"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-build-buffer ()
+  "Builds container images for the containers listed in the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" build"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-restart-buffer ()
+  "Restarts the containers listed in the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" restart"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-stop-buffer ()
+  "Stops the containers in the current buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" stop"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-down-buffer ()
+  "Runs docker-compose down on the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" down"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-pause-buffer ()
+  "Pauses the containers within the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" pause"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+(defun docker-compose-unpause-buffer ()
+  "Unpause the containers within the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" unpause"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+
+(defun docker-compose-start-buffer ()
+  "Starts the containers listed in the buffer"
+  (interactive)
+  (save-buffer)
+  (async-shell-command
+    (format "docker-compose -f \"%s\" start"
+               (standard-filename (buffer-file-name)))
+       "*dockercompose-output*"))
+
+
 ;;;###autoload
 (define-derived-mode docker-compose-mode yaml-mode "docker-compose"
   "Major mode to edit docker-compose files."


### PR DESCRIPTION
This PR adds a few commands to execute things from `docker-compose` files, via interactive selection. You can select a command to run on all services, or just a specific one.  The selection itself is using `completing-read`, so it should hook into `helm`, `ivy`, `ido` or whatever the system of the future might be.

The commands use a predefined list (gotten from copy-pasting from `docker-compose help`, hehe) and the services use `docker-compose config --services` to get a list of the services.

A special string `docker-compose-all-services-token`, which defaults to `"*all services*"` is prepended to the services list. When selected, it signals that the command is to be run on all services (e.g. with no further arguments to the command line).

### Glorious gif |o/
![docker-compose-execute](https://i.imgur.com/FKZAWBB.gif)
Please excuse the slight jittery nature of the gif. It's literally the first gif I've ever made, and I hope it gets the point across anyway.

For trivia, I've based the code and functionality on my similar [makefile-executor.el](https://github.com/thiderman/makefile-executor.el/) project, which does this exact thing but on `Makefile` targets.

Closes #19 since it contains an improved version of it.