### PR TITLE
Support for .yaml as well as .yml

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -162,7 +162,7 @@ variable for additional information about STRING and STATUS."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist
-             '("docker-compose[^/]*\\.yml\\'" . docker-compose-mode))
+             '("docker-compose[^/]*\\.ya?ml\\'" . docker-compose-mode))
 
 (provide 'docker-compose-mode)
 ;;; docker-compose-mode.el ends here


### PR DESCRIPTION
Extension `.yaml` should be supported.
https://docs.docker.com/compose/compose-file/#service-configuration-reference
> You can use either a .yml or .yaml extension for this file. They both work.