### PR TITLE
Add `compose.yaml` filename pattern to `auto-mode-alist` variable.

### DIFF
--- a/docker-compose-mode.el
+++ b/docker-compose-mode.el
@@ -163,8 +163,10 @@ variable for additional information about STRING and STATUS."
               '(docker-compose-keyword-complete-at-point)))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             '("docker-compose[^/]*\\.ya?ml\\'" . docker-compose-mode))
+(setq auto-mode-alist
+      (append '(("docker-compose[^/]*\\.ya?ml\\'" . docker-compose-mode)
+                ("compose[^/]*\\.ya?ml\\'" . docker-compose-mode))
+              auto-mode-alist))
 
 (provide 'docker-compose-mode)
 ;;; docker-compose-mode.el ends here


### PR DESCRIPTION
Both `compose.yaml` (recommended) and `compose.yml` were recently introduced as supported default manifests file names.
See [Compose file docs](https://docs.docker.com/compose/compose-file/03-compose-file/) for more info.